### PR TITLE
NEXT-0000 - Allow doubled locales

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-detail/index.js
@@ -51,7 +51,6 @@ export default {
             isSaveSuccessful: false,
             customFieldSets: null,
             parentTranslationCodeId: null,
-            translationCodeError: null,
         };
     },
 
@@ -85,9 +84,14 @@ export default {
         },
 
         usedLocaleCriteria() {
-            return (new Criteria(1, 1)).addAggregation(
-                Criteria.terms('usedTranslationIds', 'language.translationCode.id', null, null, null),
-            );
+            return (new Criteria(1, null))
+                .addFilter(Criteria.not(
+                    'and',
+                    [Criteria.equals('id', this.languageId)],
+                ))
+                .addAggregation(
+                    Criteria.terms('usedTranslationIds', 'language.translationCode.id', null, null, null),
+                );
         },
 
         allowSave() {
@@ -152,28 +156,6 @@ export default {
                 this.createdComponent();
             }
         },
-        'language.translationCodeId'(newId, oldId) {
-            this.translationCodeError = null;
-
-            if (newId === null) {
-                return;
-            }
-
-            // if no previous value, just set this translation iso as used
-            if (oldId === null) {
-                this.usedTranslationIds.push(newId);
-                return;
-            }
-
-            // if the translation iso code was changed, remove the original from the used list and replace
-            // with the newly selected code
-            const index = this.usedTranslationIds.findIndex((id) => id === oldId);
-            this.usedTranslationIds.splice(
-                index,
-                1,
-                newId,
-            );
-        },
     },
 
     created() {
@@ -200,7 +182,6 @@ export default {
             this.languageRepository.get(this.languageId).then((language) => {
                 this.isLoading = false;
                 this.language = language;
-
                 if (language.parentId) {
                     this.setParentTranslationCodeId(language.parentId);
                 }
@@ -226,8 +207,6 @@ export default {
         },
 
         onInputLanguage(parentId) {
-            this.translationCodeError = null;
-
             if (parentId) {
                 this.setParentTranslationCodeId(parentId);
             }
@@ -240,30 +219,14 @@ export default {
             this.showAlertForChangeParentLanguage = origin.parentId !== this.language.parentId;
         },
 
-        isLocaleAlreadyUsed(item) {
-            const usedByAnotherLanguage = this.usedTranslationIds.some((localeId) => {
-                return item.id === localeId;
+        isLocaleAlreadyUsed(itemId) {
+            return this.usedTranslationIds.some((localeId) => {
+                return itemId === localeId;
             });
-
-            if (usedByAnotherLanguage) {
-                return true;
-            }
-
-            if (!this.language.locale) {
-                return false;
-            }
-
-            return item.code === this.language.locale.code;
         },
 
         onSave() {
             this.isLoading = true;
-
-            if (!this.language.parentId && !this.language.translationCodeId) {
-                this.translationCodeError = {
-                    detail: this.$tc('global.error-codes.c1051bb4-d103-4f74-8988-acbcafc7fdc3'),
-                };
-            }
 
             this.languageRepository.save(this.language).then(() => {
                 this.isLoading = false;

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-detail/sw-settings-language-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-detail/sw-settings-language-detail.html.twig
@@ -122,51 +122,48 @@
 
                         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                         {% block sw_settings_language_detail_content_field_iso_code %}
-                        <sw-inherit-wrapper
+                        <sw-entity-single-select
+                            id="iso-codes"
                             v-model:value="language.translationCodeId"
-                            :inherited-value="parentTranslationCodeId"
+                            class="sw-settings-language-detail__select-iso-code"
+                            :disabled="isInherited || !acl.can('language.editor')"
+                            label-property="code"
                             :label="$tc('sw-settings-language.detail.labelIsoCode')"
                             :required="isIsoCodeRequired"
-                            :error="translationCodeError"
+                            show-clearable-button
+                            :placeholder="$tc('sw-settings-language.detail.placeholderPleaseSelect')"
+                            entity="locale"
                         >
-                            <template #content="{ currentValue, updateCurrentValue, isInherited, isInheritField, toggleInheritance, restoreInheritance, removeInheritance, error }">
-                                <sw-entity-single-select
-                                    id="iso-codes"
-                                    :value="currentValue"
-                                    class="sw-settings-language-detail__select-iso-code"
-                                    :disabled="isInherited || !acl.can('language.editor')"
-                                    label-property="code"
-                                    show-clearable-button
-                                    :placeholder="$tc('sw-settings-language.detail.placeholderPleaseSelect')"
-                                    :error="error"
-                                    entity="locale"
-                                    @update:value="updateCurrentValue"
+                            <template #result-item="{ isSelected, setValue, item, index, labelProperty, searchTerm, highlightSearchTerm, getKey }">
+                                <sw-select-result
+                                    v-tooltip="{
+                                        showDelay: 300,
+                                        message: $tc('sw-settings-language.detail.textIsoCodeIsInUse'),
+                                        disabled: !isLocaleAlreadyUsed(item?.id)
+                                    }"
+
+                                    :selected="isSelected(item)"
+                                    v-bind="{ item, index }"
+                                    @item-select="setValue"
                                 >
-                                    <template #result-item="{ isSelected, setValue, item, index, labelProperty, searchTerm, highlightSearchTerm, getKey }">
-                                        <sw-select-result
-                                            v-tooltip="{
-                                                showDelay: 300,
-                                                message: $tc('sw-settings-language.detail.textIsoCodeIsInUse'),
-                                                disabled: !isLocaleAlreadyUsed(item)
-                                            }"
-                                            :disabled="isLocaleAlreadyUsed(item)"
-                                            :selected="isSelected(item)"
-                                            v-bind="{ item, index }"
-                                            @item-select="setValue"
-                                        >
-                                            <sw-highlight-text
-                                                v-if="highlightSearchTerm"
-                                                :text="getKey(item,labelProperty) || getKey(item, `translated.${labelProperty}`)"
-                                                :search-term="searchTerm"
-                                            />
-                                            <template v-else>
-                                                {{ getKey(item,labelProperty) || getKey(item, `translated.${labelProperty}`) }}
-                                            </template>
-                                        </sw-select-result>
+
+                                    <sw-highlight-text
+                                        v-if="highlightSearchTerm"
+                                        :text="(getKey(item,labelProperty) || getKey(item, `translated.${labelProperty}`)) + (isLocaleAlreadyUsed(item?.id) ? '*' : '')"
+                                        :search-term="searchTerm"
+                                    />
+                                    <template v-else>
+                                        {{ getKey(item,labelProperty) || getKey(item, `translated.${labelProperty}`) }}
                                     </template>
-                                </sw-entity-single-select>
+                                </sw-select-result>
                             </template>
-                        </sw-inherit-wrapper>
+                            <template #hint>
+                                <div v-if="isLocaleAlreadyUsed(language.translationCodeId)">
+                                    {{ $tc('sw-settings-language.detail.textIsoCodeIsInUse') }}
+                                </div>
+                            </template>
+                        </sw-entity-single-select>
+
                         {% endblock %}
 
                         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->

--- a/src/Core/Migration/V6_7/Migration1712309989DropLanguageLocaleUnique.php
+++ b/src/Core/Migration/V6_7/Migration1712309989DropLanguageLocaleUnique.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ *
+ * @codeCoverageIgnore
+ */
+#[Package('core')]
+class Migration1712309989DropLanguageLocaleUnique extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1712309989;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeStatement('ALTER TABLE `language` DROP INDEX `uniq.translation_code_id`');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // implement update destructive
+    }
+}


### PR DESCRIPTION
### Description

The language inheritance was never implemented in the technical way, but the constraints were added.

### Solution

Languages can now have the same isoCode but get a hint about already used isoCodes

### How To Test

* Add a language e.g. "deutsch-Du" inherited from "deutsch" and try to add the locale 'de-DE' to it.